### PR TITLE
Upgrade JMS Serializer bundle to 2.2.0

### DIFF
--- a/BaseApiBundle/Resources/config/oauth2.yml
+++ b/BaseApiBundle/Resources/config/oauth2.yml
@@ -10,7 +10,7 @@ services:
         class: '%open_orchestra_api.oauth2.strategy.client_credentials_grant.class%'
         arguments:
             - '@open_orchestra_api.repository.api_client'
-            - '@serializer'
+            - '@jms_serializer'
             - '@validator'
             - '@open_orchestra_api.manager.access_token'
             - '@open_orchestra_api.repository.access_token'
@@ -20,7 +20,7 @@ services:
         class: '%open_orchestra_api.oauth2.strategy.refresh_token.class%'
         arguments:
             - '@open_orchestra_api.repository.api_client'
-            - '@serializer'
+            - '@jms_serializer'
             - '@validator'
             - '@open_orchestra_api.manager.access_token'
             - '@open_orchestra_api.repository.access_token'

--- a/BaseApiBundle/Resources/config/services.yml
+++ b/BaseApiBundle/Resources/config/services.yml
@@ -10,7 +10,7 @@ services:
     open_orchestra_api.subscriber.serializer:
         class: '%open_orchestra_api.subscriber.serializer.class%'
         arguments:
-            - '@serializer'
+            - '@jms_serializer'
             - '@annotation_reader'
             - '@controller_resolver'
         tags:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "~5.6.0",
     "doctrine/cache": "~1.6.1",
-    "jms/serializer-bundle" : "~1.1.0",
+    "jms/serializer-bundle" : "~2.2.0",
     "symfony/validator": "~2.8.6",
     "open-orchestra/open-orchestra-base-bundle": "self.version",
     "open-orchestra/open-orchestra-libs": "self.version"


### PR DESCRIPTION
Compared to currently used version, the 2.2.0 version has better support of Symfony 3.x framework features and seems to be compatible with Symfony 4.0.